### PR TITLE
check_mysql_longqueries.pl - change from Nagios::Plugin to Monitoring…

### DIFF
--- a/check_mysql_longqueries.pl
+++ b/check_mysql_longqueries.pl
@@ -25,7 +25,7 @@
 #
 # Requires the following modules:
 #        DBI
-#        Nagios::Plugin
+#        Monitoring::Plugin
 #
 # Copyright Notice: GPLv2
 #
@@ -39,11 +39,11 @@
 use warnings;
 use strict;
 use DBI;
-use Nagios::Plugin;
+use Monitoring::Plugin;
 
 
-## setup Nagios::Plugin
-my $np = Nagios::Plugin->new(
+## setup Monitoring::Plugin
+my $np = Monitoring::Plugin->new(
 	usage    => "Usage: %s [-v|--verbose] [-H <host>] [-P <port>] [-S <socket>] [-u <user>] [-p <password>] -w <warn time> -c <crit time>",
 	version  => "1.0",
 	license  => "Copyright (C) 2009  Vincent Rivellino <vrivellino\@paybycash.com>\n" .


### PR DESCRIPTION
just a small change to change from `Nagios::Plugin` to `Monitoring::Plugin`.
To which - at least - _Debian GNU/Linux_ has moved to some while ago